### PR TITLE
PUB-1616 - Ensured error message is in red

### DIFF
--- a/infrastructure/resources/b2c-polices/reset-pw.css
+++ b/infrastructure/resources/b2c-polices/reset-pw.css
@@ -11649,3 +11649,7 @@ div .attrEntry div.error {
  h1 {
   display: none;
  }
+
+#emailVerificationControl_error_message {
+  color: #d4351c;
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1616

### Change description ###

Ensure that the error message on the password reset screen is in red.

<img width="523" alt="image" src="https://user-images.githubusercontent.com/87066931/201715562-6f4246e5-b75a-4c85-96cf-8bd16975ff89.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
