### PR TITLE
PUB-1948 - Removed change button

### DIFF
--- a/infrastructure/resources/b2c-polices/reset-pw.css
+++ b/infrastructure/resources/b2c-polices/reset-pw.css
@@ -11653,8 +11653,8 @@ h1 {
 }
 
 #emailVerificationControl_but_change_claims {
-          display: none !important;
-          visibility: hidden;
+  display: none !important;
+  visibility: hidden;
 }
 
 #cancel, .buttons .sendNewCode {

--- a/infrastructure/resources/b2c-polices/reset-pw.css
+++ b/infrastructure/resources/b2c-polices/reset-pw.css
@@ -11651,3 +11651,8 @@ div .attrEntry div.error {
 #emailVerificationControl_error_message {
   color: #d4351c;
 }
+
+#emailVerificationControl_but_change_claims {
+  display: none !important;
+  visibility: hidden;
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1948

### Change description ###

Removed the change button on the Change password page. This button does not appear on the admin flow.

<img width="627" alt="image" src="https://user-images.githubusercontent.com/87066931/228822946-0f62c331-0321-4419-9b8f-5e1fee8d41d5.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
