### PR TITLE
PUB-2040 - Upgrade redis to V6

### DIFF
--- a/tf-redis-main.tf
+++ b/tf-redis-main.tf
@@ -1,10 +1,10 @@
 module "redis" {
-  source                          = "git@github.com:hmcts/cnp-module-redis?ref=master"
-  product                         = var.product
-  location                        = var.location
-  env                             = var.env
-  subnetid                        = data.azurerm_subnet.iaas.id
-  common_tags                     = var.common_tags
+  source      = "git@github.com:hmcts/cnp-module-redis?ref=master"
+  product     = var.product
+  location    = var.location
+  env         = var.env
+  subnetid    = data.azurerm_subnet.iaas.id
+  common_tags = var.common_tags
 }
 
 module "keyvault_redis_secrets" {

--- a/tf-redis-main.tf
+++ b/tf-redis-main.tf
@@ -5,7 +5,6 @@ module "redis" {
   env                             = var.env
   subnetid                        = data.azurerm_subnet.iaas.id
   common_tags                     = var.common_tags
-
 }
 
 module "keyvault_redis_secrets" {

--- a/tf-redis-main.tf
+++ b/tf-redis-main.tf
@@ -8,7 +8,6 @@ module "redis" {
 
 }
 
-
 module "keyvault_redis_secrets" {
   source = "./infrastructure/modules/kv_secrets"
 

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -12,7 +12,6 @@ module "redis-v6" {
   public_network_access_enabled = false
 }
 
-
 module "keyvault_redis_v6_secrets" {
   source = "./infrastructure/modules/kv_secrets"
 

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -1,15 +1,15 @@
 module "redis-v6" {
-  source                          = "git@github.com:hmcts/cnp-module-redis?ref=master"
-  product                         = "${var.product}-v6"
-  location                        = var.location
-  env                             = var.env
-  subnetid                        = data.azurerm_subnet.iaas.id
-  common_tags                     = var.common_tags
-  business_area                   = "sds"
-  redis_version                   = "6"
+  source        = "git@github.com:hmcts/cnp-module-redis?ref=master"
+  product       = "${var.product}-v6"
+  location      = var.location
+  env           = var.env
+  subnetid      = data.azurerm_subnet.iaas.id
+  common_tags   = var.common_tags
+  business_area = "sds"
+  redis_version = "6"
 
-  private_endpoint_enabled        = true
-  public_network_access_enabled   = false
+  private_endpoint_enabled      = true
+  public_network_access_enabled = false
 }
 
 module "keyvault_redis_v6_secrets" {

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -1,4 +1,4 @@
-module "redis" {
+module "redis-v6" {
   source                          = "git@github.com:hmcts/cnp-module-redis?ref=master"
   product                         = var.product + "-v6"
   location                        = var.location
@@ -13,7 +13,7 @@ module "redis" {
 }
 
 
-module "keyvault_redis_secrets" {
+module "keyvault_redis_v6_secrets" {
   source = "./infrastructure/modules/kv_secrets"
 
   key_vault_id = module.kv.key_vault_id

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -7,6 +7,7 @@ module "redis-v6" {
   common_tags   = var.common_tags
   business_area = "sds"
   redis_version = "6"
+  sku_name      = var.env == "prod" || var.env == "stg" ? "Premium" : "Standard"
 
   private_endpoint_enabled      = true
   public_network_access_enabled = false

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -8,8 +8,8 @@ module "redis-v6" {
   business_area                   = "sds"
   redis_version                   = "6"
 
-  private_endpoint_enabled      = true
-  public_network_access_enabled = false
+  private_endpoint_enabled        = true
+  public_network_access_enabled   = false
 }
 
 module "keyvault_redis_v6_secrets" {

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -1,11 +1,15 @@
 module "redis" {
   source                          = "git@github.com:hmcts/cnp-module-redis?ref=master"
-  product                         = var.product
+  product                         = var.product + "-v6"
   location                        = var.location
   env                             = var.env
   subnetid                        = data.azurerm_subnet.iaas.id
   common_tags                     = var.common_tags
+  business_area                   = "sds"
+  redis_version                   = "6"
 
+  private_endpoint_enabled      = true
+  public_network_access_enabled = false
 }
 
 
@@ -16,7 +20,7 @@ module "keyvault_redis_secrets" {
   tags         = var.common_tags
   secrets = [
     {
-      name  = "REDIS-HOST"
+      name  = "REDIS-V6-HOST"
       value = module.redis.host_name
       tags = {
         "source" : "Redis"
@@ -25,7 +29,7 @@ module "keyvault_redis_secrets" {
       expiration_date = local.secret_expiry
     },
     {
-      name  = "REDIS-PORT"
+      name  = "REDIS-V6-PORT"
       value = module.redis.redis_port
       tags = {
         "source" : "Redis"
@@ -34,7 +38,7 @@ module "keyvault_redis_secrets" {
       expiration_date = local.secret_expiry
     },
     {
-      name  = "REDIS-PASSWORD"
+      name  = "REDIS-V6-PASSWORD"
       value = module.redis.access_key
       tags = {
         "source" : "Redis"

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -20,7 +20,7 @@ module "keyvault_redis_v6_secrets" {
   secrets = [
     {
       name  = "REDIS-V6-HOST"
-      value = module.redis.host_name
+      value = module.redis-v6.host_name
       tags = {
         "source" : "Redis"
       }
@@ -29,7 +29,7 @@ module "keyvault_redis_v6_secrets" {
     },
     {
       name  = "REDIS-V6-PORT"
-      value = module.redis.redis_port
+      value = module.redis-v6.redis_port
       tags = {
         "source" : "Redis"
       }
@@ -38,7 +38,7 @@ module "keyvault_redis_v6_secrets" {
     },
     {
       name  = "REDIS-V6-PASSWORD"
-      value = module.redis.access_key
+      value = module.redis-v6.access_key
       tags = {
         "source" : "Redis"
       }

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -1,6 +1,6 @@
 module "redis-v6" {
   source                          = "git@github.com:hmcts/cnp-module-redis?ref=master"
-  product                         = var.product + "-v6"
+  product                         = "${var.product}-v6"
   location                        = var.location
   env                             = var.env
   subnetid                        = data.azurerm_subnet.iaas.id

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -7,7 +7,6 @@ module "redis-v6" {
   common_tags   = var.common_tags
   business_area = "sds"
   redis_version = "6"
-  sku_name      = var.env == "prod" || var.env == "stg" ? "Premium" : "Standard"
 
   private_endpoint_enabled      = true
   public_network_access_enabled = false

--- a/tf-redis-v6-main.tf
+++ b/tf-redis-v6-main.tf
@@ -48,6 +48,6 @@ module "keyvault_redis_v6_secrets" {
   ]
 
   depends_on = [
-    module.redis
+    module.redis-v6
   ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2040

### Change description ###

This is an upgrade of Redis to V6.

The approach is to avoid downtime is to create a new version of Redis, switch the instances to use that and then remove the old one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
